### PR TITLE
⬆ Bump kohlrahbi from 1.4.1 to 1.4.2

### DIFF
--- a/dependencies/kohlrahbi-requirements.in
+++ b/dependencies/kohlrahbi-requirements.in
@@ -1,1 +1,1 @@
-kohlrahbi>=1.4.1
+kohlrahbi>=1.4.2

--- a/dependencies/kohlrahbi-requirements.txt
+++ b/dependencies/kohlrahbi-requirements.txt
@@ -18,7 +18,7 @@ colorlog==6.8.2
     # via kohlrahbi
 et-xmlfile==1.1.0
     # via openpyxl
-kohlrahbi==1.4.1
+kohlrahbi==1.4.2
     # via -r kohlrahbi-requirements.in
 lxml==5.2.2
     # via python-docx


### PR DESCRIPTION
https://github.com/Hochfrequenz/kohlrahbi/releases/tag/v1.4.2