### PR TITLE
chore(ci): pip-compile --upgrade mirror-requirements.in

### DIFF
--- a/dependencies/mirror-requirements.txt
+++ b/dependencies/mirror-requirements.txt
@@ -12,9 +12,9 @@ aiosignal==1.3.2
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-attrs==24.3.0
+attrs==25.1.0
     # via aiohttp
-edi-energy-scraper==2.0.3
+edi-energy-scraper==2.0.5
     # via -r mirror-requirements.in
 efoli==1.4.0
     # via edi-energy-scraper
@@ -24,7 +24,7 @@ frozenlist==1.5.0
     #   aiosignal
 idna==3.10
     # via yarl
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via edi-energy-scraper
 multidict==6.1.0
     # via
@@ -34,13 +34,13 @@ propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-pydantic==2.10.5
+pydantic==2.10.6
     # via edi-energy-scraper
 pydantic-core==2.27.2
     # via pydantic
-pypdf==5.1.0
+pypdf==5.2.0
     # via edi-energy-scraper
-pytz==2024.2
+pytz==2025.1
     # via
     #   edi-energy-scraper
     #   efoli


### PR DESCRIPTION
bumps edi-energy-scraper from 2.0.3 to 2.0.5
