### PR TITLE
ci(ebd): emit cross-FV format_versions.json manifest

### DIFF
--- a/.github/workflows/ebdamame_rebdhuhn.yml
+++ b/.github/workflows/ebdamame_rebdhuhn.yml
@@ -44,6 +44,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.XMLMIGSAHBS_READ_TOKEN }}
           FORMAT_VERSION: ${{ matrix.output }}
         run: docker compose up --abort-on-container-exit
+      - name: Regenerate format_versions.json (enumerable FV list for AI/consumers)
+        # ebd_toolchain emits the per-FV discovery files (index.json / pruefi_to_key.json /
+        # ebd.schema.json) into each FV dir; this adds the one cross-FV manifest, which no
+        # single (per-FV) matrix job can otherwise produce. We rescan the whole checkout so
+        # the manifest lists every format version present, not just the one this job scraped.
+        working-directory: machine-readable_entscheidungsbaumdiagramme
+        run: |
+          python3 <<'PY'
+          import json, os, re
+          fvs = sorted(d for d in os.listdir(".") if re.fullmatch(r"FV\d{4}", d) and os.path.isdir(d))
+          def valid_from(fv: str) -> str:
+              return f"20{fv[2:4]}-{fv[4:6]}-01"
+          data = {
+              "latest": fvs[-1] if fvs else None,
+              "format_versions": [{"format_version": fv, "valid_from": valid_from(fv)} for fv in fvs],
+          }
+          with open("format_versions.json", "w", encoding="utf-8") as fh:
+              json.dump(data, fh, ensure_ascii=False, indent=2)
+              fh.write("\n")
+          print(f"wrote format_versions.json with {len(fvs)} format versions")
+          PY
       - name: Get current time
         uses: srfrnk/current-time@master
         id: current-time

--- a/.github/workflows/ebdamame_rebdhuhn.yml
+++ b/.github/workflows/ebdamame_rebdhuhn.yml
@@ -46,16 +46,24 @@ jobs:
         run: docker compose up --abort-on-container-exit
       - name: Regenerate format_versions.json (enumerable FV list for AI/consumers)
         # ebd_toolchain emits the per-FV discovery files (index.json / pruefi_to_key.json /
-        # ebd.schema.json) into each FV dir; this adds the one cross-FV manifest, which no
-        # single (per-FV) matrix job can otherwise produce. We rescan the whole checkout so
-        # the manifest lists every format version present, not just the one this job scraped.
+        # ebd.schema.json) into each FV dir; this adds the one cross-FV manifest, which no single
+        # (per-FV) matrix job can otherwise produce. We list the FV dirs present in the checkout
+        # (this job's freshly-written FV included) and take valid_from from efoli — the authoritative
+        # BDEW dates, which are NOT the FV label and not always the 1st (e.g. FV2504 -> 2025-06-06).
+        # Existing-FV jobs recompute an identical manifest, so create-pull-request includes it only in
+        # the PR of the job that actually adds/changes a format version; it self-heals on the next run.
         working-directory: machine-readable_entscheidungsbaumdiagramme
         run: |
+          python3 -m pip install --quiet efoli
           python3 <<'PY'
           import json, os, re
+          from efoli import EdifactFormatVersion, get_edifact_format_version_valid_from
           fvs = sorted(d for d in os.listdir(".") if re.fullmatch(r"FV\d{4}", d) and os.path.isdir(d))
-          def valid_from(fv: str) -> str:
-              return f"20{fv[2:4]}-{fv[4:6]}-01"
+          def valid_from(fv: str) -> str | None:
+              try:
+                  return get_edifact_format_version_valid_from(EdifactFormatVersion(fv)).isoformat()
+              except ValueError:
+                  return None  # FV not (yet) known to efoli
           data = {
               "latest": fvs[-1] if fvs else None,
               "format_versions": [{"format_version": fv, "valid_from": valid_from(fv)} for fv in fvs],

--- a/ebd-tooling/docker-compose.yaml
+++ b/ebd-tooling/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   
    scrape-and-plot: 
      build: . 
-     image: ghcr.io/hochfrequenz/ebd_toolchain:v1.2.2
+     image: ghcr.io/hochfrequenz/ebd_toolchain:v1.3.0
      # If you run into 'manifest unknown' during docker pull, try replacing `:latest` with `:v1.2.3`. 
      # where v1.2.3 is the latest version of the GHCR image, which can be found here: 
      # https://github.com/Hochfrequenz/ebd_toolchain/pkgs/container/ebd_toolchain 


### PR DESCRIPTION
**Draft — depends on Hochfrequenz/ebd_toolchain#397** (which emits the per-FV `index.json` / `pruefi_to_key.json` / `ebd.schema.json`). Part of making the EBD data AI-discoverable.

## What
Adds one step to `ebdamame_rebdhuhn.yml` that regenerates a repo-root **`format_versions.json`** in the `machine-readable_entscheidungsbaumdiagramme` checkout:
```json
{ "latest": "FV2610", "format_versions": [ { "format_version": "FV2304", "valid_from": "2023-04-01" }, … ] }
```
It's produced here (not in ebd_toolchain) because the toolchain runs **per format version** and can't enumerate all of them; the workflow's matrix jobs each check out the whole machine-readable repo, so the step rescans every `FV*` dir. The manifest is picked up by the existing `create-pull-request` step, same as the per-FV files.

## Why
Gives AI/programmatic consumers an **enumerable FV list without a live directory crawl** (which format versions exist, their validity start, and the latest) — the entry point before resolving a Prüfidentifikator/EBD in the per-FV `index.json`/`pruefi_to_key.json`.

## Notes / for review
- Each matrix job rewrites the manifest identically (it scans the full checkout), so the 3 per-FV PRs carry the same manifest — no divergence.
- Kept as a draft until #397 merges (so the per-FV artifacts it complements actually exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)